### PR TITLE
sets EDITOR env var

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,6 @@
 source $ZSH/oh-my-zsh.sh
 
+export EDITOR=nvim
 export DOTNET_ROOT="/usr/local/share/dotnet"
 # nodenv
 eval "$(nodenv init -)"


### PR DESCRIPTION
# EDITOR ENV VAR

so things like `gh` use nvim instead of nano for editing
